### PR TITLE
Allow X-Access-Token header to be used along side access_token query string

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": false,
+  "bracketSpacing": true
+}

--- a/examples/kitchensink/src/config/environments/development.ts
+++ b/examples/kitchensink/src/config/environments/development.ts
@@ -19,6 +19,10 @@ export default async (): Promise<Config> => ({
     gzip: true,
     indexCatchAll: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
   },
   database: {
     // uri: 'postgres://localhost:5432/tie_development',

--- a/examples/kitchensink/src/config/environments/devredis.ts
+++ b/examples/kitchensink/src/config/environments/devredis.ts
@@ -8,6 +8,10 @@ export default async () => ({
     gzip: true,
     indexCatchAll: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
   },
   database: {
     uri: 'sqlite::memory:',

--- a/examples/kitchensink/src/config/environments/mailhog.ts
+++ b/examples/kitchensink/src/config/environments/mailhog.ts
@@ -9,6 +9,10 @@ export default async () => ({
     gzip: true,
     indexCatchAll: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
   },
   database: {
     uri: 'postgres://localhost:5432/tie_test',

--- a/packages/create-hyperstack/template-app/src/config/environments/development.ts
+++ b/packages/create-hyperstack/template-app/src/config/environments/development.ts
@@ -17,7 +17,7 @@ export default async () => ({
     sendValidationErrors: true,
     serveStatic: true,
     bearer: {
-      header: 'x-axccess-token',
+      header: 'x-access-token',
       query: 'access_token',
     },
   },

--- a/packages/create-hyperstack/template-app/src/config/environments/development.ts
+++ b/packages/create-hyperstack/template-app/src/config/environments/development.ts
@@ -16,6 +16,10 @@ export default async () => ({
     indexCatchAll: true,
     sendValidationErrors: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
   },
   database: {
     // you can use sqlite for swift development, but recommended to use a real postgres

--- a/packages/create-hyperstack/template-app/src/config/environments/production.ts
+++ b/packages/create-hyperstack/template-app/src/config/environments/production.ts
@@ -63,6 +63,10 @@ export default async () => ({
     gzip: true,
     indexCatchAll: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
 
     // in production we're being paranoid by default. We don't give out hints to anyone. turn on if you think otherwise.
     sendValidationErrors: false,

--- a/packages/create-hyperstack/template-app/src/config/environments/production.ts
+++ b/packages/create-hyperstack/template-app/src/config/environments/production.ts
@@ -64,7 +64,7 @@ export default async () => ({
     indexCatchAll: true,
     serveStatic: true,
     bearer: {
-      header: 'x-axccess-token',
+      header: 'x-access-token',
       query: 'access_token',
     },
 

--- a/packages/create-hyperstack/template-blank/src/config/environments/development.ts
+++ b/packages/create-hyperstack/template-blank/src/config/environments/development.ts
@@ -17,7 +17,7 @@ export default async () => ({
     sendValidationErrors: true,
     serveStatic: true,
     bearer: {
-      header: 'x-axccess-token',
+      header: 'x-access-token',
       query: 'access_token',
     },
   },

--- a/packages/create-hyperstack/template-blank/src/config/environments/development.ts
+++ b/packages/create-hyperstack/template-blank/src/config/environments/development.ts
@@ -16,6 +16,10 @@ export default async () => ({
     indexCatchAll: true,
     sendValidationErrors: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
   },
   database: {
     // you can use sqlite for swift development, but recommended to use a real postgres

--- a/packages/create-hyperstack/template-blank/src/config/environments/production.ts
+++ b/packages/create-hyperstack/template-blank/src/config/environments/production.ts
@@ -63,6 +63,10 @@ export default async () => ({
     gzip: true,
     indexCatchAll: true,
     serveStatic: true,
+    bearer: {
+      header: 'x-axccess-token',
+      query: 'access_token',
+    },
 
     // in production we're being paranoid by default. We don't give out hints to anyone. turn on if you think otherwise.
     sendValidationErrors: false,

--- a/packages/create-hyperstack/template-blank/src/config/environments/production.ts
+++ b/packages/create-hyperstack/template-blank/src/config/environments/production.ts
@@ -64,7 +64,7 @@ export default async () => ({
     indexCatchAll: true,
     serveStatic: true,
     bearer: {
-      header: 'x-axccess-token',
+      header: 'x-access-token',
       query: 'access_token',
     },
 

--- a/packages/initializer-jwt/src/index.ts
+++ b/packages/initializer-jwt/src/index.ts
@@ -26,12 +26,13 @@ export default (
     if (!jwtSecretOrPublicKey) {
       throw new Error('No JWT secret is set in configuration')
     }
+    const bearer = config.controllers!.bearer || undefined
 
     const { MustAuthWithJWT, MustAuthRouteWithJWT, signJWT, verifyJWT } =
       authWithJWT({
         secret: jwtSecretOrPublicKey,
         loader,
-        bearer: undefined,
+        bearer,
         jwtOptions: {
           expiresIn: config.controllers!.jwtExpiry || '14d',
           algorithm: config.controllers!.jwtAlgorithm || 'HS512',

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -149,6 +149,10 @@ export interface Config {
     helmet?: boolean | any
     json?: boolean | any
     urlencoded?: boolean | any
+    bearer?: {
+      header: string
+      query: string
+    }
   }
   mailers?: MailerSettings
   workers?: {


### PR DESCRIPTION
To be able to perform the following action, i would like to propose the attached changes

```bash
curl -s -H "X-Access-Token: ${TOKEN}" "http://localhost:5150/notes" | jq -r
```

Since hyperstack is opinionated, I also propose to include the config by default in the templates

And I've also added a default simple prettierrc since vscode complains about double qoutes :-)