### PR TITLE
Fix initializers loading

### DIFF
--- a/packages/hyperstack/src/controllers.ts
+++ b/packages/hyperstack/src/controllers.ts
@@ -66,7 +66,7 @@ export const getControllerConfig = (context: Context) => {
   const appRoot = store.app!.root
   const logger = store.logger
   const middleware = store.logging!.middleware
-  const initializers = store.initializers
+  const initializers = store.initializers?.initializers
   const controllerPath = path.join(appRoot, 'app', 'controllers')
 
   const {

--- a/packages/hyperstack/test/__snapshots__/controllers.spec.ts.snap
+++ b/packages/hyperstack/test/__snapshots__/controllers.spec.ts.snap
@@ -114,7 +114,6 @@ Array [
   "options",
   "patch",
   "post",
-  "pri",
   "propfind",
   "proppatch",
   "purge",

--- a/packages/hyperstack/test/__snapshots__/controllers.spec.ts.snap
+++ b/packages/hyperstack/test/__snapshots__/controllers.spec.ts.snap
@@ -12,15 +12,12 @@ Object {
   "helmet": undefined,
   "indexCatchAll": true,
   "initializers": Object {
-    "initializers": Object {
-      "afterControllers": Array [
-        [Function],
-      ],
-      "beforeControllers": Array [
-        [Function],
-      ],
-    },
-    "props": Object {},
+    "afterControllers": Array [
+      [Function],
+    ],
+    "beforeControllers": Array [
+      [Function],
+    ],
   },
   "json": undefined,
   "logging": Object {
@@ -45,15 +42,12 @@ Object {
   "helmet": undefined,
   "indexCatchAll": undefined,
   "initializers": Object {
-    "initializers": Object {
-      "afterControllers": Array [
-        [Function],
-      ],
-      "beforeControllers": Array [
-        [Function],
-      ],
-    },
-    "props": Object {},
+    "afterControllers": Array [
+      [Function],
+    ],
+    "beforeControllers": Array [
+      [Function],
+    ],
   },
   "json": undefined,
   "logging": Object {
@@ -120,6 +114,7 @@ Array [
   "options",
   "patch",
   "post",
+  "pri",
   "propfind",
   "proppatch",
   "purge",

--- a/packages/hyperstack/test/controllers.spec.ts
+++ b/packages/hyperstack/test/controllers.spec.ts
@@ -19,16 +19,14 @@ describe('controllers', () => {
 
       const cfg = getControllerConfig(context)
       expect(cfg.logging).toBeTruthy()
-      expect(
-        cfg.initializers?.initializers.beforeControllers!.length
-      ).toBeGreaterThan(0)
-      expect(
-        cfg.initializers?.initializers.afterControllers!.length
-      ).toBeGreaterThan(0)
+      expect(cfg.initializers?.beforeControllers!.length).toBeGreaterThan(0)
+      expect(cfg.initializers?.afterControllers!.length).toBeGreaterThan(0)
 
       cfg.logging.logger = 'test-was-ok'
       if (cfg.staticFolder) {
-        cfg.staticFolder = cfg.staticFolder.toString().replace(/^.*hyperstack/, '')
+        cfg.staticFolder = cfg.staticFolder
+          .toString()
+          .replace(/^.*hyperstack/, '')
       }
 
       expect(cfg).toMatchSnapshot(`controllers-snap-${env}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,65 +119,6 @@ importers:
       ts-node-dev: 1.1.8
       tsc-alias: 1.6.9
 
-  examples/tiny-url:
-    specifiers:
-      '@hyperstackjs/initializer-jwt': 1.0.29
-      '@hyperstackjs/testing': 1.0.29
-      '@types/jest': ^28.1.5
-      '@types/lodash': ^4.14.182
-      '@types/node': ^17.0.38
-      '@types/validator': ^13.7.2
-      concurrently: ^7.2.1
-      enquirer: ^2.3.6
-      hyperstack: 1.0.29
-      jest: ^28.1.1
-      jest-extended: ^3.0.1
-      lodash: ^4.17.21
-      mkdirp: ^1.0.4
-      node-notifier: 10.0.1
-      rimraf: ^3.0.2
-      sqlite3: ^5.0.8
-      stylomatic: 0.4.5
-      time-require: ^0.1.2
-      ts-jest: ^28.0.4
-      ts-node: ^10.8.1
-      ts-node-dev: ^2.0.0
-      tsc-alias: ^1.6.9
-      tsconfig-paths: ^4.0.0
-      tsup: ^6.1.0
-      typescript: ^4.7.4
-      typescript-cp: ^0.1.5
-      zod: ^3.17.3
-    dependencies:
-      '@hyperstackjs/initializer-jwt': link:../../packages/initializer-jwt
-      hyperstack: link:../../packages/hyperstack
-      lodash: 4.17.21
-      sqlite3: 5.0.8
-      ts-node: 10.8.1_x2utdhayajzrh747hktprshhby
-      tsconfig-paths: 4.0.0
-      typescript: 4.7.4
-      zod: 3.17.3
-    devDependencies:
-      '@hyperstackjs/testing': link:../../packages/testing
-      '@types/jest': 28.1.5
-      '@types/lodash': 4.14.182
-      '@types/node': 17.0.45
-      '@types/validator': 13.7.4
-      concurrently: 7.2.1
-      enquirer: 2.3.6
-      jest: 28.1.1_2unznl2n4pnytna5dybx4qmlla
-      jest-extended: 3.0.1_jest@28.1.1
-      mkdirp: 1.0.4
-      node-notifier: 10.0.1
-      rimraf: 3.0.2
-      stylomatic: 0.4.5_2unznl2n4pnytna5dybx4qmlla
-      time-require: 0.1.2
-      ts-jest: 28.0.4_zv2ltmnvcc5apkdaecods742je
-      ts-node-dev: 2.0.0_cmtl2lddv2elmbemb6ncv4z6ju
-      tsc-alias: 1.6.9
-      tsup: 6.1.0_mu66ohdiwyrigyorzidgf4bsdu
-      typescript-cp: 0.1.5_typescript@4.7.4
-
   packages/_empty:
     specifiers:
       lodash: ^4.17.21
@@ -10901,7 +10842,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_@types+node@12.20.52
+      jest: 28.1.1_ts-node@10.8.1
       jest-util: 28.1.1
       json5: 2.2.1
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,65 @@ importers:
       ts-node-dev: 1.1.8
       tsc-alias: 1.6.9
 
+  examples/tiny-url:
+    specifiers:
+      '@hyperstackjs/initializer-jwt': 1.0.29
+      '@hyperstackjs/testing': 1.0.29
+      '@types/jest': ^28.1.5
+      '@types/lodash': ^4.14.182
+      '@types/node': ^17.0.38
+      '@types/validator': ^13.7.2
+      concurrently: ^7.2.1
+      enquirer: ^2.3.6
+      hyperstack: 1.0.29
+      jest: ^28.1.1
+      jest-extended: ^3.0.1
+      lodash: ^4.17.21
+      mkdirp: ^1.0.4
+      node-notifier: 10.0.1
+      rimraf: ^3.0.2
+      sqlite3: ^5.0.8
+      stylomatic: 0.4.5
+      time-require: ^0.1.2
+      ts-jest: ^28.0.4
+      ts-node: ^10.8.1
+      ts-node-dev: ^2.0.0
+      tsc-alias: ^1.6.9
+      tsconfig-paths: ^4.0.0
+      tsup: ^6.1.0
+      typescript: ^4.7.4
+      typescript-cp: ^0.1.5
+      zod: ^3.17.3
+    dependencies:
+      '@hyperstackjs/initializer-jwt': link:../../packages/initializer-jwt
+      hyperstack: link:../../packages/hyperstack
+      lodash: 4.17.21
+      sqlite3: 5.0.8
+      ts-node: 10.8.1_x2utdhayajzrh747hktprshhby
+      tsconfig-paths: 4.0.0
+      typescript: 4.7.4
+      zod: 3.17.3
+    devDependencies:
+      '@hyperstackjs/testing': link:../../packages/testing
+      '@types/jest': 28.1.5
+      '@types/lodash': 4.14.182
+      '@types/node': 17.0.45
+      '@types/validator': 13.7.4
+      concurrently: 7.2.1
+      enquirer: 2.3.6
+      jest: 28.1.1_2unznl2n4pnytna5dybx4qmlla
+      jest-extended: 3.0.1_jest@28.1.1
+      mkdirp: 1.0.4
+      node-notifier: 10.0.1
+      rimraf: 3.0.2
+      stylomatic: 0.4.5_2unznl2n4pnytna5dybx4qmlla
+      time-require: 0.1.2
+      ts-jest: 28.0.4_zv2ltmnvcc5apkdaecods742je
+      ts-node-dev: 2.0.0_cmtl2lddv2elmbemb6ncv4z6ju
+      tsc-alias: 1.6.9
+      tsup: 6.1.0_mu66ohdiwyrigyorzidgf4bsdu
+      typescript-cp: 0.1.5_typescript@4.7.4
+
   packages/_empty:
     specifiers:
       lodash: ^4.17.21
@@ -10842,7 +10901,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_ts-node@10.8.1
+      jest: 28.1.1_@types+node@12.20.52
       jest-util: 28.1.1
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Initializers are not loaded correctly since the initializers are assigned to the app context like that:
```
  context.update(setters.initializers, {
    initializers: { initializers: inits, props },
  })
```

and being loaded like that:
```
  const store = context.store()
  const initializers = store.initializers
```

had to be loaded like that:
```
  const store = context.store()
  const initializers = store.initializers?.initializers
```