### PR TITLE
Add cookie authentication

### DIFF
--- a/docs/website/docs/01_the-app/01_controllers.md
+++ b/docs/website/docs/01_the-app/01_controllers.md
@@ -168,6 +168,7 @@ controllers: {
   gzip: true,
   indexCatchAll: true, // serve from public/index.html
   serveStatic: true, // serve static content from public/
+  authCookieName: 'token', // specify cookie (should be http only cookie) name containes the JWT of the user
   // helmet?: bool | {..}
   // json?: bool | {..}
   // urlencoded?: bool | {..}

--- a/docs/website/docs/01_the-app/01_controllers.md
+++ b/docs/website/docs/01_the-app/01_controllers.md
@@ -168,7 +168,7 @@ controllers: {
   gzip: true,
   indexCatchAll: true, // serve from public/index.html
   serveStatic: true, // serve static content from public/
-  authCookieName: 'token', // specify cookie (should be http only cookie) name containes the JWT of the user
+  authCookieName: 'auth-cookie-name' | true | false, // set to true to enable cookie auth with default cookie name (HS_AUTH), specify desired cookie name or set to false to turn off cookie auth
   // helmet?: bool | {..}
   // json?: bool | {..}
   // urlencoded?: bool | {..}

--- a/docs/website/docs/02_digging-deeper/01_authentication.md
+++ b/docs/website/docs/02_digging-deeper/01_authentication.md
@@ -2,12 +2,12 @@
 
 _Hyperstack_ comes with authentication, **and aims to provide the same plug-in authentication experience** as _Devise_ did for Rails.
 
-To narrow down the scope, **Hyperstack offers authentication with _JWT_**. This means clients authenticate, and gets back a JWT token, to use as a Bearer token in following requests.
+To narrow down the scope, **Hyperstack offers authentication with _JWT_**. This means clients authenticate, and gets back a JWT token, to use as a Bearer token or as `http only` cookie in following requests.
 
 For that, we have a few components:
 
 * **JWT logic**, verfication, and encryption
-* Middleware to **verify and authenticate** a user with a Bearer token
+* Middleware to **verify and authenticate** a user with a Bearer token or with `http only` cookie
 * `currentUser` infra to **identify, authenticate, and load a current user** into the current authenticated request for convenience
 * A generic `User` model, `Auth` controller, and `Auth` mailer for login, registration, reset password, and more.
 
@@ -19,7 +19,7 @@ While you get these things **out of the box**, it's nice to see how things work 
 ```ts
 import jwt from '@hyperstackjs/initializer-jwt'
 
-export default jwt(context => async (payload) => {
+export default jwt((context) => async (payload) => {
   const { User } = context.models()
   const user = await User.findOne({ where: { username: payload.sub } })
   if (!user) {

--- a/examples/kitchensink/src/config/environments/test.ts
+++ b/examples/kitchensink/src/config/environments/test.ts
@@ -14,6 +14,7 @@ export default async () => ({
     indexCatchAll: true,
     serveStatic: true,
     sendValidationErrors: true,
+    authCookieName: 'token',
   },
   database: {
     uri: `${process.env.POSTGRES_URL || 'postgres://localhost:5432/tie_test'}`,
@@ -23,7 +24,7 @@ export default async () => ({
     synchronize: true, // this is important for the models
     truncate: true,
     migrate: false, // this is important for e2e testing. there's a migration with no model
-    logging: false, // eslint-disable-line no-console
+    logging: false,
   },
   mailers: {
     send: true,

--- a/examples/kitchensink/src/config/environments/test.ts
+++ b/examples/kitchensink/src/config/environments/test.ts
@@ -14,7 +14,6 @@ export default async () => ({
     indexCatchAll: true,
     serveStatic: true,
     sendValidationErrors: true,
-    authCookieName: 'token',
   },
   database: {
     uri: `${process.env.POSTGRES_URL || 'postgres://localhost:5432/tie_test'}`,

--- a/packages/hypercontroller/src/jwt.ts
+++ b/packages/hypercontroller/src/jwt.ts
@@ -67,7 +67,7 @@ const authWithJWT = ({
   loader: any
   jwtOptions?: any
   bearer?: any
-  authCookieName?: string | boolean
+  authCookieName?: string | null
 }) => {
   if (!secret) {
     throw new Error('no JWT secret set')

--- a/packages/hypercontroller/src/jwt.ts
+++ b/packages/hypercontroller/src/jwt.ts
@@ -67,7 +67,7 @@ const authWithJWT = ({
   loader: any
   jwtOptions?: any
   bearer?: any
-  authCookieName: string | null | boolean
+  authCookieName?: string | boolean
 }) => {
   if (!secret) {
     throw new Error('no JWT secret set')

--- a/packages/hypercontroller/src/jwt.ts
+++ b/packages/hypercontroller/src/jwt.ts
@@ -22,7 +22,9 @@ const createAuth = (verify: any, { loader, bearer, authCookieName }: any) => {
   )
 
   return async (req: Request) => {
-    const token = permit.check(req) || req.cookies[authCookieName]
+    const token = authCookieName
+      ? req.cookies[authCookieName]
+      : permit.check(req)
     if (!token) {
       throw new HttpResponseUnauthorized('no token')
     }
@@ -65,7 +67,7 @@ const authWithJWT = ({
   loader: any
   jwtOptions?: any
   bearer?: any
-  authCookieName: string
+  authCookieName: string | null | boolean
 }) => {
   if (!secret) {
     throw new Error('no JWT secret set')

--- a/packages/hypercontroller/test/__snapshots__/jwt.spec.ts.snap
+++ b/packages/hypercontroller/test/__snapshots__/jwt.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`hypercontroller/jwt fails - JWT should only accept HS512 1`] = `
+exports[`hypercontroller/jwt bearer auth fails - JWT should only accept HS512 1`] = `
 Object {
   "body": Object {},
   "headers": Object {
@@ -28,7 +28,7 @@ Object {
 }
 `;
 
-exports[`hypercontroller/jwt fails auth 1`] = `
+exports[`hypercontroller/jwt bearer auth fails auth 1`] = `
 Object {
   "body": Object {},
   "headers": Object {
@@ -56,35 +56,7 @@ Object {
 }
 `;
 
-exports[`hypercontroller/jwt fails auth 2`] = `
-Object {
-  "body": Object {},
-  "headers": Object {
-    "connection": "close",
-    "content-length": "9",
-    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
-    "content-type": "text/html; charset=utf-8",
-    "cross-origin-embedder-policy": "require-corp",
-    "cross-origin-opener-policy": "same-origin",
-    "cross-origin-resource-policy": "same-origin",
-    "expect-ct": "max-age=0",
-    "origin-agent-cluster": "?1",
-    "referrer-policy": "no-referrer",
-    "strict-transport-security": "max-age=15552000; includeSubDomains",
-    "vary": "Accept-Encoding",
-    "www-authenticate": "",
-    "x-content-type-options": "nosniff",
-    "x-dns-prefetch-control": "off",
-    "x-download-options": "noopen",
-    "x-frame-options": "SAMEORIGIN",
-    "x-permitted-cross-domain-policies": "none",
-    "x-xss-protection": "0",
-  },
-  "status": 401,
-}
-`;
-
-exports[`hypercontroller/jwt fails auth 3`] = `
+exports[`hypercontroller/jwt bearer auth fails auth 2`] = `
 Object {
   "body": Object {},
   "headers": Object {
@@ -112,7 +84,7 @@ Object {
 }
 `;
 
-exports[`hypercontroller/jwt passes auth 1`] = `
+exports[`hypercontroller/jwt bearer auth passes auth 1`] = `
 Object {
   "body": Object {
     "its": "alright",
@@ -141,7 +113,122 @@ Object {
 }
 `;
 
-exports[`hypercontroller/jwt process auth with cookie 1`] = `
+exports[`hypercontroller/jwt cookie authentication authCookieName contains string value should not pass auth - invaild jwt 1`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "connection": "close",
+    "content-length": "9",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "text/html; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "www-authenticate": "",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 401,
+}
+`;
+
+exports[`hypercontroller/jwt cookie authentication authCookieName contains string value should pass auth via auth cookie 1`] = `
+Object {
+  "body": Object {
+    "its": "alright",
+  },
+  "headers": Object {
+    "connection": "close",
+    "content-length": "17",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "application/json; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 200,
+}
+`;
+
+exports[`hypercontroller/jwt cookie authentication authCookieName is false - no cookie auth should pass auth via bearer token 1`] = `
+Object {
+  "body": Object {
+    "its": "alright",
+  },
+  "headers": Object {
+    "connection": "close",
+    "content-length": "17",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "application/json; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 200,
+}
+`;
+
+exports[`hypercontroller/jwt cookie authentication authCookieName is not set - no cookie auth should pass auth via bearer token 1`] = `
+Object {
+  "body": Object {
+    "its": "alright",
+  },
+  "headers": Object {
+    "connection": "close",
+    "content-length": "17",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "application/json; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 200,
+}
+`;
+
+exports[`hypercontroller/jwt cookie authentication authCookieName is true - user uses default cookie name should pass auth via auth cookie 1`] = `
 Object {
   "body": Object {
     "its": "alright",

--- a/packages/hypercontroller/test/__snapshots__/jwt.spec.ts.snap
+++ b/packages/hypercontroller/test/__snapshots__/jwt.spec.ts.snap
@@ -61,6 +61,34 @@ Object {
   "body": Object {},
   "headers": Object {
     "connection": "close",
+    "content-length": "9",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "text/html; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "www-authenticate": "",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 401,
+}
+`;
+
+exports[`hypercontroller/jwt fails auth 3`] = `
+Object {
+  "body": Object {},
+  "headers": Object {
+    "connection": "close",
     "content-length": "8",
     "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
     "content-type": "text/html; charset=utf-8",
@@ -85,6 +113,35 @@ Object {
 `;
 
 exports[`hypercontroller/jwt passes auth 1`] = `
+Object {
+  "body": Object {
+    "its": "alright",
+  },
+  "headers": Object {
+    "connection": "close",
+    "content-length": "17",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "application/json; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 200,
+}
+`;
+
+exports[`hypercontroller/jwt process auth with cookie 1`] = `
 Object {
   "body": Object {
     "its": "alright",

--- a/packages/hypercontroller/test/jwt.spec.ts
+++ b/packages/hypercontroller/test/jwt.spec.ts
@@ -35,7 +35,7 @@ class Api {
 
 const app = createServer({
   controllers: [Api],
-  opts: { logging: { logger }, cookieSecret: 'evil-supply' },
+  opts: { logging: { logger }, cookieSecret: 'auth-cookie-secret' },
 })
 describe('hypercontroller/jwt', () => {
   it('passes auth', async () => {

--- a/packages/hypercontroller/test/jwt.spec.ts
+++ b/packages/hypercontroller/test/jwt.spec.ts
@@ -1,6 +1,6 @@
 import request from 'supertest'
 import { sign } from 'jsonwebtoken'
-
+import { resolveAuthCookieName } from '../../initializer-jwt/src/index'
 import {
   Controller,
   Get,
@@ -16,66 +16,138 @@ const signJWT = (payload: any) =>
     expiresIn: '1h',
   })
 
-const { MustAuthWithJWT } = authWithJWT({
-  secret: 'testing-secret',
-  loader: async (payload: any) => ({
-    user: { name: 'joe', email: payload.email },
-  }),
-  authCookieName: 'token',
-})
+const createApp = (
+  shouldSetCookie: boolean,
+  authCookieNameValue?: string | boolean
+) => {
+  const { MustAuthWithJWT } = shouldSetCookie
+    ? authWithJWT({
+        secret: 'testing-secret',
+        loader: async (payload: any) => ({
+          user: { name: 'joe', email: payload.email },
+        }),
+        authCookieName: resolveAuthCookieName(authCookieNameValue),
+      })
+    : authWithJWT({
+        secret: 'testing-secret',
+        loader: async (payload: any) => ({
+          user: { name: 'joe', email: payload.email },
+        }),
+      })
 
-@MustAuthWithJWT
-@Controller('api')
-class Api {
-  @Get('foobar')
-  async foobar(_req: any, _res: any) {
-    return new HttpResponseOK({ its: 'alright' })
+  @MustAuthWithJWT
+  @Controller('api')
+  class Api {
+    @Get('foobar')
+    async foobar(_req: any, _res: any) {
+      return new HttpResponseOK({ its: 'alright' })
+    }
   }
+
+  return createServer({
+    controllers: [Api],
+    opts: { logging: { logger }, cookieSecret: 'auth-cookie-secret' },
+  })
 }
 
-const app = createServer({
-  controllers: [Api],
-  opts: { logging: { logger }, cookieSecret: 'auth-cookie-secret' },
-})
 describe('hypercontroller/jwt', () => {
-  it('passes auth', async () => {
-    const key = signJWT({ email: 'joe@ericsson.com' })
-    await expectWithSnapshot(
-      200,
-      request(app)
-        .get('/api/foobar')
-        .set({ Authorization: `Bearer ${key}` })
-    )
-  })
-  it('process auth with cookie', async () => {
-    const key = signJWT({ email: 'joe@ericsson.com' })
-    await expectWithSnapshot(
-      200,
-      request(app)
-        .get('/api/foobar')
-        .set('Cookie', [`token=${key}`])
-    )
-  })
-  it('fails - JWT should only accept HS512', async () => {
-    const key = sign({ email: 'joe@ericsson.com' }, 'testing-secret', {
-      expiresIn: '1h',
+  describe('bearer auth', () => {
+    const app = createApp(false)
+
+    it('passes auth', async () => {
+      const key = signJWT({ email: 'joe@ericsson.com' })
+      await expectWithSnapshot(
+        200,
+        request(app)
+          .get('/api/foobar')
+          .set({ Authorization: `Bearer ${key}` })
+      )
     })
-    await expectWithSnapshot(
-      401,
-      request(app)
-        .get('/api/foobar')
-        .set({ Authorization: `Bearer ${key}` })
-    )
+    it('fails - JWT should only accept HS512', async () => {
+      const key = sign({ email: 'joe@ericsson.com' }, 'testing-secret', {
+        expiresIn: '1h',
+      })
+      await expectWithSnapshot(
+        401,
+        request(app)
+          .get('/api/foobar')
+          .set({ Authorization: `Bearer ${key}` })
+      )
+    })
+    it('fails auth', async () => {
+      await expectWithSnapshot(
+        401,
+        request(app)
+          .get('/api/foobar')
+          .set({ Authorization: 'Bearer bad-token' })
+      )
+
+      await expectWithSnapshot(401, request(app).get('/api/foobar'))
+    })
   })
-  it('fails auth', async () => {
-    await expectWithSnapshot(
-      401,
-      request(app).get('/api/foobar').set({ Authorization: 'Bearer bad-token' })
-    )
-    await expectWithSnapshot(
-      401,
-      request(app).get('/api/foobar').set('Cookie', [`token=123`])
-    )
-    await expectWithSnapshot(401, request(app).get('/api/foobar'))
+
+  describe('cookie authentication', () => {
+    describe('authCookieName contains string value', () => {
+      const app = createApp(true, 'my_cookie')
+
+      it('should pass auth via auth cookie', async () => {
+        const key = signJWT({ email: 'joe@ericsson.com' })
+        await expectWithSnapshot(
+          200,
+          request(app)
+            .get('/api/foobar')
+            .set('Cookie', [`my_cookie=${key}`])
+        )
+      })
+
+      it('should not pass auth - invaild jwt', async () => {
+        await expectWithSnapshot(
+          401,
+          request(app).get('/api/foobar').set('Cookie', [`my_cookie=123`])
+        )
+      })
+    })
+
+    describe('authCookieName is true - user uses default cookie name', () => {
+      const app = createApp(true, true)
+
+      it('should pass auth via auth cookie', async () => {
+        const key = signJWT({ email: 'joe@ericsson.com' })
+        await expectWithSnapshot(
+          200,
+          request(app)
+            .get('/api/foobar')
+            .set('Cookie', [`HS_AUTH=${key}`])
+        )
+      })
+    })
+
+    describe('authCookieName is false - no cookie auth', () => {
+      const app = createApp(true, false)
+
+      it('should pass auth via bearer token', async () => {
+        const key = signJWT({ email: 'joe@ericsson.com' })
+        await expectWithSnapshot(
+          200,
+          request(app)
+            .get('/api/foobar')
+            .set({ Authorization: `Bearer ${key}` })
+        )
+      })
+    })
+
+    describe('authCookieName is not set - no cookie auth', () => {
+      const app = createApp(false)
+
+      it('should pass auth via bearer token', async () => {
+        const key = signJWT({ email: 'joe@ericsson.com' })
+        await expectWithSnapshot(
+          200,
+          request(app)
+            .get('/api/foobar')
+            .set({ Authorization: `Bearer ${key}` })
+        )
+      })
+    })
   })
 })

--- a/packages/hypercontroller/test/jwt.spec.ts
+++ b/packages/hypercontroller/test/jwt.spec.ts
@@ -21,6 +21,7 @@ const { MustAuthWithJWT } = authWithJWT({
   loader: async (payload: any) => ({
     user: { name: 'joe', email: payload.email },
   }),
+  authCookieName: 'HS_AUTH',
 })
 
 @MustAuthWithJWT
@@ -34,7 +35,7 @@ class Api {
 
 const app = createServer({
   controllers: [Api],
-  opts: { logging: { logger } },
+  opts: { logging: { logger }, cookieSecret: 'evil-supply' },
 })
 describe('hypercontroller/jwt', () => {
   it('passes auth', async () => {

--- a/packages/initializer-jwt/src/index.ts
+++ b/packages/initializer-jwt/src/index.ts
@@ -21,13 +21,20 @@ export const getProps = () => context.initializerProps<JWTProps>(key)
 export const resolveAuthCookieName = (
   cookieNameConfig?: string | boolean
 ): string | null => {
-  if (typeof cookieNameConfig == 'boolean' && cookieNameConfig) {
+  if (!cookieNameConfig) {
+    return null
+  }
+
+  if (cookieNameConfig === true) {
     return DEFAULT_AUTH_COOKIE_NAME
-  }
-  if (typeof cookieNameConfig == 'string' && cookieNameConfig.length > 0) {
+  } else if (
+    typeof cookieNameConfig == 'string' &&
+    cookieNameConfig.length > 0
+  ) {
     return cookieNameConfig
+  } else {
+    return null
   }
-  return null
 }
 
 export default (

--- a/packages/initializer-jwt/src/index.ts
+++ b/packages/initializer-jwt/src/index.ts
@@ -6,6 +6,8 @@ import createDebug from 'debug'
 import type { Request } from '@hyperstackjs/hypercontroller'
 const debug = createDebug('hyperstack:init-jwt')
 
+const DEFAULT_AUTH_COOKIE_NAME = 'HS_AUTH'
+
 export interface JWTProps {
   MustAuthWithJWT: any
   MustAuthRouteWithJWT: any
@@ -37,6 +39,8 @@ export default (
           expiresIn: config.controllers!.jwtExpiry || '14d',
           algorithm: config.controllers!.jwtAlgorithm || 'HS512',
         },
+        authCookieName:
+          config.controllers!.authCookieName || DEFAULT_AUTH_COOKIE_NAME,
       })
 
     return {

--- a/packages/initializer-jwt/src/index.ts
+++ b/packages/initializer-jwt/src/index.ts
@@ -19,7 +19,7 @@ const key = 'jwt'
 export const getProps = () => context.initializerProps<JWTProps>(key)
 
 export const resolveAuthCookieName = (
-  cookieNameConfig: string | null | boolean
+  cookieNameConfig?: string | boolean
 ): string | null => {
   if (typeof cookieNameConfig == 'boolean' && cookieNameConfig) {
     return DEFAULT_AUTH_COOKIE_NAME

--- a/packages/initializer-jwt/test/index.spec.ts
+++ b/packages/initializer-jwt/test/index.spec.ts
@@ -1,5 +1,35 @@
-describe('one', () => {
-  it('true', () => {
-    expect(1).toEqual(1)
+import { DEFAULT_AUTH_COOKIE_NAME, resolveAuthCookieName } from '../src/index'
+
+describe('resolveAuthCookieName', () => {
+  it('should resolve the given cookie name (cookie auth is on using given cookie name)', () => {
+    const expectedCookieName = 'token'
+    const actualCookieName = resolveAuthCookieName(expectedCookieName)
+
+    expect(actualCookieName).toEqual(expectedCookieName)
+  })
+
+  it('should resolve default auth cookie name when input is true (cookie auth is on using default cookie name)', () => {
+    const expectedCookieName = DEFAULT_AUTH_COOKIE_NAME
+    const actualCookieName = resolveAuthCookieName(true)
+
+    expect(actualCookieName).toEqual(expectedCookieName)
+  })
+
+  it('should return null when cookie name value is false (cookie auth is off)', () => {
+    const actualCookieName = resolveAuthCookieName(false)
+
+    expect(actualCookieName).toEqual(null)
+  })
+
+  it('should return null when no name sent (cookie auth is off)', () => {
+    const actualCookieName = resolveAuthCookieName(null)
+
+    expect(actualCookieName).toEqual(null)
+  })
+
+  it('should return null when no name sent (cookie auth is off)', () => {
+    const actualCookieName = resolveAuthCookieName('')
+
+    expect(actualCookieName).toEqual(null)
   })
 })

--- a/packages/initializer-jwt/test/index.spec.ts
+++ b/packages/initializer-jwt/test/index.spec.ts
@@ -22,7 +22,7 @@ describe('resolveAuthCookieName', () => {
   })
 
   it('should return null when no name sent (cookie auth is off)', () => {
-    const actualCookieName = resolveAuthCookieName(null)
+    const actualCookieName = resolveAuthCookieName(undefined)
 
     expect(actualCookieName).toEqual(null)
   })

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -140,7 +140,7 @@ export interface Config {
     jwtSecret?: string
     jwtExpiry?: string
     jwtAlgorithm?: string
-    authCookieName?: string
+    authCookieName?: string | null | boolean
     baseUrl?: string
     serveStatic?: boolean
     indexCatchAll?: boolean

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -140,7 +140,7 @@ export interface Config {
     jwtSecret?: string
     jwtExpiry?: string
     jwtAlgorithm?: string
-    authCookieName?: string | null | boolean
+    authCookieName?: string | boolean
     baseUrl?: string
     serveStatic?: boolean
     indexCatchAll?: boolean

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -140,6 +140,7 @@ export interface Config {
     jwtSecret?: string
     jwtExpiry?: string
     jwtAlgorithm?: string
+    authCookieName?: string
     baseUrl?: string
     serveStatic?: boolean
     indexCatchAll?: boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,65 +119,6 @@ importers:
       ts-node-dev: 1.1.8
       tsc-alias: 1.6.9
 
-  examples/tiny-url:
-    specifiers:
-      '@hyperstackjs/initializer-jwt': 1.0.29
-      '@hyperstackjs/testing': 1.0.29
-      '@types/jest': ^28.1.5
-      '@types/lodash': ^4.14.182
-      '@types/node': ^17.0.38
-      '@types/validator': ^13.7.2
-      concurrently: ^7.2.1
-      enquirer: ^2.3.6
-      hyperstack: 1.0.29
-      jest: ^28.1.1
-      jest-extended: ^3.0.1
-      lodash: ^4.17.21
-      mkdirp: ^1.0.4
-      node-notifier: 10.0.1
-      rimraf: ^3.0.2
-      sqlite3: ^5.0.8
-      stylomatic: 0.4.5
-      time-require: ^0.1.2
-      ts-jest: ^28.0.4
-      ts-node: ^10.8.1
-      ts-node-dev: ^2.0.0
-      tsc-alias: ^1.6.9
-      tsconfig-paths: ^4.0.0
-      tsup: ^6.1.0
-      typescript: ^4.7.4
-      typescript-cp: ^0.1.5
-      zod: ^3.17.3
-    dependencies:
-      '@hyperstackjs/initializer-jwt': link:../../packages/initializer-jwt
-      hyperstack: link:../../packages/hyperstack
-      lodash: 4.17.21
-      sqlite3: 5.0.8
-      ts-node: 10.8.1_x2utdhayajzrh747hktprshhby
-      tsconfig-paths: 4.0.0
-      typescript: 4.7.4
-      zod: 3.17.3
-    devDependencies:
-      '@hyperstackjs/testing': link:../../packages/testing
-      '@types/jest': 28.1.5
-      '@types/lodash': 4.14.182
-      '@types/node': 17.0.45
-      '@types/validator': 13.7.4
-      concurrently: 7.2.1
-      enquirer: 2.3.6
-      jest: 28.1.1_2unznl2n4pnytna5dybx4qmlla
-      jest-extended: 3.0.1_jest@28.1.1
-      mkdirp: 1.0.4
-      node-notifier: 10.0.1
-      rimraf: 3.0.2
-      stylomatic: 0.4.5_2unznl2n4pnytna5dybx4qmlla
-      time-require: 0.1.2
-      ts-jest: 28.0.4_zv2ltmnvcc5apkdaecods742je
-      ts-node-dev: 2.0.0_cmtl2lddv2elmbemb6ncv4z6ju
-      tsc-alias: 1.6.9
-      tsup: 6.1.0_mu66ohdiwyrigyorzidgf4bsdu
-      typescript-cp: 0.1.5_typescript@4.7.4
-
   packages/_empty:
     specifiers:
       lodash: ^4.17.21
@@ -196,14 +137,14 @@ importers:
 
   packages/create-hyperstack/template-app:
     specifiers:
-      '@hyperstackjs/initializer-jwt': 1.0.29
-      '@hyperstackjs/testing': 1.0.29
+      '@hyperstackjs/initializer-jwt': 1.0.30
+      '@hyperstackjs/testing': 1.0.30
       '@types/jest': ^28.1.5
       '@types/lodash': ^4.14.182
       '@types/node': ^17.0.38
       '@types/validator': ^13.7.2
       concurrently: ^7.2.1
-      hyperstack: 1.0.29
+      hyperstack: 1.0.30
       jest: ^28.1.1
       jest-extended: ^3.0.1
       lodash: ^4.17.21
@@ -255,14 +196,14 @@ importers:
 
   packages/create-hyperstack/template-blank:
     specifiers:
-      '@hyperstackjs/initializer-jwt': 1.0.29
-      '@hyperstackjs/testing': 1.0.29
+      '@hyperstackjs/initializer-jwt': 1.0.30
+      '@hyperstackjs/testing': 1.0.30
       '@types/jest': ^28.1.5
       '@types/lodash': ^4.14.182
       '@types/node': ^17.0.38
       '@types/validator': ^13.7.2
       concurrently: ^7.2.1
-      hyperstack: 1.0.29
+      hyperstack: 1.0.30
       jest: ^28.1.1
       jest-extended: ^3.0.1
       lodash: ^4.17.21
@@ -329,8 +270,8 @@ importers:
   packages/hypercontroller:
     specifiers:
       '@anatine/zod-openapi': ^1.3.0
-      '@hyperstackjs/hypernight': 1.0.29
-      '@hyperstackjs/typings': 1.0.29
+      '@hyperstackjs/hypernight': 1.0.30
+      '@hyperstackjs/typings': 1.0.30
       ajv: ^6.12.3
       async-express-mw: ^0.1.2
       body-parser: ^1.20.0
@@ -381,7 +322,7 @@ importers:
 
   packages/hypermodel:
     specifiers:
-      '@hyperstackjs/typings': 1.0.29
+      '@hyperstackjs/typings': 1.0.30
       debug: ^4.3.4
       glob: ^8.0.3
       lodash: ^4.17.21
@@ -449,7 +390,7 @@ importers:
 
   packages/hyperportal:
     specifiers:
-      '@hyperstackjs/typings': 1.0.29
+      '@hyperstackjs/typings': 1.0.30
       as-table: ^1.0.55
       colorette: ^2.0.16
       lodash: ^4.17.21
@@ -463,11 +404,11 @@ importers:
   packages/hyperstack:
     specifiers:
       '@faker-js/faker': ^7.1.0
-      '@hyperstackjs/gen': 1.0.29
-      '@hyperstackjs/hypercontroller': 1.0.29
-      '@hyperstackjs/hypermodel': 1.0.29
-      '@hyperstackjs/hyperportal': 1.0.29
-      '@hyperstackjs/hyperworker': 1.0.29
+      '@hyperstackjs/gen': 1.0.30
+      '@hyperstackjs/hypercontroller': 1.0.30
+      '@hyperstackjs/hypermodel': 1.0.30
+      '@hyperstackjs/hyperportal': 1.0.30
+      '@hyperstackjs/hyperworker': 1.0.30
       as-table: ^1.0.55
       colorette: ^2.0.16
       debug: ^4.3.4
@@ -507,7 +448,7 @@ importers:
 
   packages/hyperworker:
     specifiers:
-      '@hyperstackjs/typings': 1.0.29
+      '@hyperstackjs/typings': 1.0.30
       bullmq: ^1.85.3
       debug: ^4.3.4
       ejs: ^3.1.8
@@ -536,10 +477,10 @@ importers:
 
   packages/initializer-jwt:
     specifiers:
-      '@hyperstackjs/hypercontroller': 1.0.29
-      '@hyperstackjs/typings': 1.0.29
+      '@hyperstackjs/hypercontroller': 1.0.30
+      '@hyperstackjs/typings': 1.0.30
       debug: ^4.3.4
-      hyperstack: 1.0.29
+      hyperstack: 1.0.30
     dependencies:
       '@hyperstackjs/hypercontroller': link:../hypercontroller
       '@hyperstackjs/typings': link:../typings
@@ -549,7 +490,7 @@ importers:
   packages/testing:
     specifiers:
       debug: ^4.3.4
-      hyperstack: 1.0.29
+      hyperstack: 1.0.30
       lodash: ^4.17.21
       supertest: ^6.2.3
       testcontainers: ^8.10.1
@@ -10901,7 +10842,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_@types+node@12.20.52
+      jest: 28.1.1_ts-node@10.8.1
       jest-util: 28.1.1
       json5: 2.2.1
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Currently, authentication is enabled only via the Bearer header, this PR is adding the option to recognize also via a cookie (http only)