### PR TITLE
Handle URI error without log

### DIFF
--- a/packages/hypercontroller/src/server/error-handler.ts
+++ b/packages/hypercontroller/src/server/error-handler.ts
@@ -26,7 +26,7 @@ const errorHandler =
           validationErrors: err.errors,
         })
       )
-    } else if (err.isModelError) {
+    } else if (err.isModelError || err instanceof URIError) {
       responseSender(res, new HttpResponseBadRequest({ error: err.message }))
     } else if (err) {
       // prefer a request-bound logger because of occasional child loggers & context that's bound to these

--- a/packages/hypercontroller/test/__snapshots__/responses.spec.ts.snap
+++ b/packages/hypercontroller/test/__snapshots__/responses.spec.ts.snap
@@ -87,6 +87,35 @@ exports[`hypercontroller/responses requests 1`] = `
 }
 `;
 
+exports[`hypercontroller/responses uri error 1`] = `
+{
+  "body": {
+    "error": "this is a uri error",
+  },
+  "headers": {
+    "connection": "close",
+    "content-length": "31",
+    "content-security-policy": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+    "content-type": "application/json; charset=utf-8",
+    "cross-origin-embedder-policy": "require-corp",
+    "cross-origin-opener-policy": "same-origin",
+    "cross-origin-resource-policy": "same-origin",
+    "expect-ct": "max-age=0",
+    "origin-agent-cluster": "?1",
+    "referrer-policy": "no-referrer",
+    "strict-transport-security": "max-age=15552000; includeSubDomains",
+    "vary": "Accept-Encoding",
+    "x-content-type-options": "nosniff",
+    "x-dns-prefetch-control": "off",
+    "x-download-options": "noopen",
+    "x-frame-options": "SAMEORIGIN",
+    "x-permitted-cross-domain-policies": "none",
+    "x-xss-protection": "0",
+  },
+  "status": 400,
+}
+`;
+
 exports[`hypercontroller/responses validation error 1`] = `
 {
   "body": {

--- a/packages/hypercontroller/test/responses.spec.ts
+++ b/packages/hypercontroller/test/responses.spec.ts
@@ -31,6 +31,11 @@ class Api {
     throw new ValidationError({ errors: [] })
   }
 
+  @Get('uri-error')
+  async uriErrors(_req: Request, _res: Response) {
+    throw new URIError("this is a uri error")
+  }
+
   @Get('raw-object')
   async rawObject(_req: Request, _res: Response) {
     return { hello: 'ok' }
@@ -53,6 +58,9 @@ describe('hypercontroller/responses', () => {
   })
   it('validation error', async () => {
     await expectWithSnapshot(400, request(app).get('/api/validation-error'))
+  })
+  it('uri error', async () => {
+    await expectWithSnapshot(400, request(app).get('/api/uri-error'))
   })
   it('raw object', async () => {
     await expectWithSnapshot(200, request(app).get('/api/raw-object'))


### PR DESCRIPTION
Hi @jondot 
Our app is public and receives a lot of requests of this form (seems like a kind of directory traversal attack):
/theme/META-INF/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/%c0%ae%c0%ae/

This path is not being caught by any of our controllers, and since we have a static folder the app is trying to serve index.html to every such path after it decodes the path, and since the decoding fails a URIError is thrown and being caught by the error handler which produces an error log and returns 400.

I propose that in such an error return only 400 since there is no actual need for an error log which creates redundant noise of error logs.